### PR TITLE
Fixed sorting of servers to reflect Best-Fit

### DIFF
--- a/simulator/components/infrastructure/server.py
+++ b/simulator/components/infrastructure/server.py
@@ -216,12 +216,14 @@ class Server(ObjectCollection):
         """
 
         vms_allocated = 0
-
+        def delta(x,y):
+            return abs(x-y)
         # Verifying if all VMs could be hosted by the list of servers
         for vm in virtual_machines:
-            # Sorting servers according to their demand (descending)
+            
+            # Sorting servers according to their current capacity (descending)
             servers = sorted(servers, key=lambda sv:
-                (-sv.cpu_demand, -sv.memory_demand, -sv.disk_demand))
+                (-delta(sv.cpu_demand, sv.cpu_capacity), -delta(sv.memory_demand, sv.memory_capacity), -delta(sv.disk_demand, sv.disk_capacity)))
 
             for server in servers:
                 if server.has_capacity_to_host(vm):


### PR DESCRIPTION
The proposed method sorts servers and use a Best-Fit strategy to simulate migrations. However, to carry out the ordering, only the demand of the servers is taken into account and not the current free space, that is, the absolute difference between demand and capacity.